### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install node.js and run
 node server
 ```
 
-Open your browser to `http://localhost:l337/index.html'
+Open your browser to `http://localhost:1337/index.html'
 
 ## License
 


### PR DESCRIPTION
Node.js port was incorrectly listed as l337 (with a lower-case L instead
of the number one)
